### PR TITLE
Add filter args to document fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test": "jest",
     "build": "tsdx build",
     "prepare": "tsdx build",
+    "dev": "ts-node-dev --respawn --no-notify --transpile-only -P server.tsconfig.json ./src/scripts/start-server.ts --ignore=built",
     "server": "ts-node --transpile-only -P server.tsconfig.json ./src/scripts/start-server.ts --ignore=built"
   },
   "devDependencies": {

--- a/src/types/object-types/author.ts
+++ b/src/types/object-types/author.ts
@@ -78,9 +78,17 @@ export const authorType: GraphQLObjectType = new GraphQLObjectType<
           description:
             "The order to return the documents in, defaults to OLDEST",
         },
+        pathPrefix: {
+          type: GraphQLString,
+          description:
+            "A path that all returned docs must have at the beginning of their paths",
+        },
       },
       resolve(root, args, ctx) {
-        return sortDocuments(getAuthorDocuments(root, ctx), args.sortedBy);
+        return sortDocuments(
+          getAuthorDocuments(root, ctx, { pathPrefix: args.pathPrefix }),
+          args.sortedBy
+        );
       },
     },
     workspaces: {

--- a/src/types/object-types/workspace.ts
+++ b/src/types/object-types/workspace.ts
@@ -128,9 +128,24 @@ export const workspaceType: GraphQLObjectType = new GraphQLObjectType<
         sortedBy: {
           type: documentSortEnum,
         },
+        pathPrefix: {
+          type: GraphQLString,
+          description:
+            "A path that all returned docs must have at the beginning of their paths",
+        },
+        versionsByAuthor: {
+          type: GraphQLString,
+          description: "An author address ",
+        },
       },
       resolve(root, args) {
-        return sortDocuments(root.documents(), args.sortedBy);
+        return sortDocuments(
+          root.documents({
+            pathPrefix: args.pathPrefix,
+            versionsByAuthor: args.versionsByAuthor,
+          }),
+          args.sortedBy
+        );
       },
     },
   }),

--- a/src/types/query.ts
+++ b/src/types/query.ts
@@ -14,6 +14,7 @@ import {
   GraphQLNonNull,
   GraphQLString,
   GraphQLList,
+  GraphQLScalarType,
 } from "graphql";
 import { Context } from "../types";
 import { authorType, authorSortEnum } from "./object-types/author";
@@ -93,9 +94,21 @@ export const queryType = new GraphQLObjectType<{}, Context>({
         sortedBy: {
           type: documentSortEnum,
         },
+        pathPrefix: {
+          type: GraphQLString,
+          description:
+            "A path that all returned docs must have at the beginning of their paths",
+        },
+        versionsByAuthor: {
+          type: GraphQLString,
+          description: "An author address ",
+        },
       },
       resolve(_root, args, ctx) {
-        const docs = getAllDocuments(ctx);
+        const docs = getAllDocuments(ctx, {
+          pathPrefix: args.pathPrefix,
+          versionsByAuthor: args.versionsByAuthor,
+        });
         return sortDocuments(docs, args.sortedBy);
       },
     },

--- a/src/util.ts
+++ b/src/util.ts
@@ -59,9 +59,18 @@ export async function initWorkspace(address: string, ctx: Context) {
   }
 }
 
-export function getAllDocuments(ctx: Context) {
+export function getAllDocuments(
+  ctx: Context,
+  filters: {
+    pathPrefix?: string;
+    versionsByAuthor?: string;
+  } = {}
+) {
   return ctx.workspaces.flatMap((workspace) => {
-    return workspace.documents();
+    return workspace.documents({
+      pathPrefix: filters.pathPrefix,
+      versionsByAuthor: filters.versionsByAuthor,
+    });
   });
 }
 
@@ -109,7 +118,13 @@ export function getAllAuthors(ctx: Context) {
   ).map((address) => ({ address }));
 }
 
-export function getAuthorDocuments(author: ESAuthor, ctx: Context): Document[] {
+export function getAuthorDocuments(
+  author: ESAuthor,
+  ctx: Context,
+  filters: {
+    pathPrefix?: string;
+  } = {}
+): Document[] {
   const workspaces = author.fromWorkspace
     ? ctx.workspaces.filter((ws) => author.fromWorkspace === ws.workspace)
     : ctx.workspaces;
@@ -121,6 +136,7 @@ export function getAuthorDocuments(author: ESAuthor, ctx: Context): Document[] {
 
     return workspace.documents({
       versionsByAuthor: author.address,
+      pathPrefix: filters.pathPrefix,
     });
   });
 }


### PR DESCRIPTION
Adds filtering to document fields, so you can write queries like this:

```
{
  workspaces {
    documents(pathPrefix: "/wiki") {
      ... on ES3Document {
        path
      }
    }
  }
}
```

Also supports the `versionsByAuthor` arg. Will be easy to add more `QueryOpts` from earthstar as they are implemented ( @cinnamon-bun seems like `participatingAuthor` isn't used in the most recently published release?)

Best of all, this opens the door to partial syncing.

Closes #6